### PR TITLE
updated Swiper to 3.3.1 and fixed nested Swipers bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/zefoy/angular2-swiper-wrapper.git"
   },
   "dependencies": {
-    "swiper": "3.3.0"
+    "swiper": "3.3.1"
   },
   "devDependencies": {
     "@angular/common": "2.0.0",

--- a/src/swiper-view.component.ts
+++ b/src/swiper-view.component.ts
@@ -115,12 +115,8 @@ export class SwiperViewComponent implements OnInit, DoCheck, OnDestroy, OnChange
 
     if (changes) {
       this.ngOnDestroy();
-
-      setTimeout(() => {
-        this.ngOnInit();
-
-        this.update();
-      }, 0);
+      this.ngOnInit();
+      this.update();
     }
   }
 


### PR DESCRIPTION
Removed the Settimeout in Swiper-view.component.ts > ngDocheck, which resolved the issue with non-responding buttons in the parent swiper when using nested swipers.

Otherwise you have two consecutive timeouts, because update() in the same class also creates a timeout.